### PR TITLE
add 'feature_directories' to meteor-addon-list.json

### DIFF
--- a/meteor-addon-list.json
+++ b/meteor-addon-list.json
@@ -13,5 +13,13 @@
     "Automation"
   ],
   "discord": "https://discord.gg/rRFf5JJWhd",
-  "homepage": "https://www.meteoraddons.com"
+  "homepage": "https://www.meteoraddons.com",
+  "feature_directories": {
+    "commands": [
+      "commands"
+    ],
+    "modules": [
+      "modules"
+    ]
+  }
 }


### PR DESCRIPTION
adds `feature_directories` field in meteor-addon-list.json to enable feature descriptions of this addon on [meteoraddons.com](https://www.meteoraddons.com/)
